### PR TITLE
Use vtex-page-padding instead of tachyons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Header using vtex-page-padding class instead of tachyons ph6-xl, ph7-m, ph3-s, w-90-l.
 
 ## [1.2.1] - 2018-10-25
 

--- a/react/components/TopMenu.js
+++ b/react/components/TopMenu.js
@@ -87,7 +87,7 @@ class TopMenu extends Component {
         'fixed bw1 bb b--light-gray top-0 z-999': fixed,
       }
     )
-    const contentClasses = 'w-100 w-90-l center flex justify-center pb4 pv2-m pv6-l ph3-s ph7-m ph6-xl'
+    const contentClasses = 'vtex-page-padding w-100 center flex justify-center pb4 pv2-m pv6-l'
     return (
       <ReactResizeDetector handleWidth>
         {

--- a/react/components/TopMenu.js
+++ b/react/components/TopMenu.js
@@ -19,7 +19,7 @@ class TopMenu extends Component {
 
   renderLogo(mobileMode, logoUrl, logoTitle) {
     return (
-      <div className="vtex-top-menu__logo flex justify-start ml3 w-25-m w-30-l">
+      <div className="vtex-top-menu__logo flex justify-start pl4 w-25-m w-30-l">
         <Link to="/" className="outline-0">
           <ExtensionPoint
             id="logo"

--- a/react/components/TopMenu.js
+++ b/react/components/TopMenu.js
@@ -6,7 +6,7 @@ import classNames from 'classnames'
 import ReactResizeDetector from 'react-resize-detector'
 
 const LOGO_WIDTH_MOBILE = 90
-const LOGO_WIDTH_DESKTOP = 150
+const LOGO_WIDTH_DESKTOP = 140
 const LOGO_HEIGHT_MOBILE = 30
 const LOGO_HEIGHT_DESKTOP = 50
 const MINICART_ICON_SIZE_MOBILE = 23
@@ -19,7 +19,7 @@ class TopMenu extends Component {
 
   renderLogo(mobileMode, logoUrl, logoTitle) {
     return (
-      <div className="vtex-top-menu__logo flex justify-start w-25-m w-30-l">
+      <div className="vtex-top-menu__logo flex justify-start ml3 w-25-m w-30-l">
         <Link to="/" className="outline-0">
           <ExtensionPoint
             id="logo"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Use vtex-page-padding class instead of tachyons ph6-xl, ph7-m, ph4-s and w-90-l.

#### What problem is this solving?
The page padding should be equal. This change makes sure that this constraint is applied.

#### How should this be manually tested?
[Access this workspace](https://alignheader--storecomponents.myvtex.com/)

#### Screenshots or example usage
This is a refactoring, so the component looks and behaves as before.

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
