### PR TITLE
Fix scroll performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Better scroll performance
+
 ## [1.3.0] - 2018-11-05
 ### Added
 - Configuration to show, searchBar, and login buttons

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.3.1] - 2018-11-06
+
 ### Fixed
 - Better scroll performance
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "dreamstore-header",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "title": "VTEX Header",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Header component",

--- a/react/index.js
+++ b/react/index.js
@@ -67,13 +67,11 @@ class Header extends Component {
     const scroll = window.scrollY
     const { scrollHeight } = this._root.current
 
-    if (scroll < scrollHeight && this.state.showMenuPopup) {
+    const showMenuPopup = scroll >= scrollHeight
+
+    if (showMenuPopup !== this.state.showMenuPopup) {
       this.setState({
-        showMenuPopup: false
-      })
-    } else if (scroll >= scrollHeight) {
-      this.setState({
-        showMenuPopup: true
+        showMenuPopup
       })
     }
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says

Right now, the header is trying to `setState` on every scroll event after a certain threshold. This greatly affects the scroll performance, and is especially noticeable when the app tries to scroll smoothly.

Now it will only try to set state if the state `showMenuPopup` is different.

#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
