### PR TITLE
Make header more compatible in mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Hide the `SearchBar` when scroll the page in mobile devices. 
+- In the above scenario, a icon is displayed and when clicked the `Searchbar` is rendered.
 
 ## [1.4.0] - 2018-11-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.5.0] - 2018-11-07
 ### Added
 - Hide the `SearchBar` when scroll the page in mobile devices. 
 - In the above scenario, a icon is displayed and when clicked the `Searchbar` is rendered.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "dreamstore-header",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "title": "VTEX Header",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Header component",

--- a/react/components/TopMenu.js
+++ b/react/components/TopMenu.js
@@ -2,6 +2,8 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { intlShape, injectIntl } from 'react-intl'
 import { ExtensionPoint, Link } from 'render'
+import { Button, IconSearch } from 'vtex.styleguide'
+
 import classNames from 'classnames'
 import ReactResizeDetector from 'react-resize-detector'
 
@@ -13,6 +15,8 @@ const MINICART_ICON_SIZE_MOBILE = 23
 const MINICART_ICON_SIZE_DESKTOP = 30
 const LOGIN_ICON_SIZE_MOBILE = 23
 const LOGIN_ICON_SIZE_DESKTOP = 30
+const SEARCH_ICON_SIZE_MOBILE = 20
+const SEARCH_ICON_SIZE_DESKTOP = 30
 
 class TopMenu extends Component {
   translate = id => this.props.intl.formatMessage({ id: `header.${id}` })
@@ -49,20 +53,24 @@ class TopMenu extends Component {
     />
     return showSearchBar && (
       <div className={`vtex-top-menu__search-bar flex pa2-m w-100 w-50-m w-40-l ${mobileMode ? 'order-2' : 'order-1'}`}>
-        {mobileMode ? (mobileMode && !fixed) && searchBar : searchBar}
+        {mobileMode ? !fixed && searchBar : searchBar}
       </div>
     )
   }
 
   renderIcons(mobileMode) {
-    const { leanMode, showLogin, fixed } = this.props
+    const { leanMode, fixed, showLogin } = this.props
+    const { searchActive } = this.state
 
     return (
       <div className={
         `vtex-top-menu__icons flex justify-end items-center w-25-m w-30-l ${mobileMode ? 'order-1 ml-auto' : 'order-2'}`
       }>
         <div className="mr7-m">
-       {showLogin && <ExtensionPoint
+          {(mobileMode && fixed) && showLogin && <Button icon variation="tertiary">
+            <IconSearch size={mobileMode ? SEARCH_ICON_SIZE_MOBILE : SEARCH_ICON_SIZE_DESKTOP} color="gray" />
+          </Button>}
+          <ExtensionPoint
             id="login"
             iconClasses="gray"
             labelClasses="gray"
@@ -93,12 +101,13 @@ class TopMenu extends Component {
         'vtex-top-menu-static' : !fixed,
       }
     )
-    const contentClasses = 'w-100 w-90-l center flex justify-center pb4 pv2-m pv6-l ph3-s ph7-m ph6-xl'
     return (
       <ReactResizeDetector handleWidth>
         {
           width => {
             const mobileMode = width < 640 || (global.__RUNTIME__.hints.mobile && (!width || width < 640))
+            const contentClasses = `w-100 w-90-l center flex justify-center  ${mobileMode & !fixed ? 'pb4' : ''}  pv2-m pv6-l ph3-s ph7-m ph6-xl`
+
             return (
               <div className={containerClasses}>
                 <div className={contentClasses}>

--- a/react/components/TopMenu.js
+++ b/react/components/TopMenu.js
@@ -61,7 +61,7 @@ class TopMenu extends Component {
 
   renderMobileSearchBar(searchActive) {
     return (
-      <div className="flex justify-start pa2 pt3 relative w-100">
+      <div className="flex justify-start pa1 pr6 pt3 relative w-100">
         <div className="w-80">
           <ExtensionPoint
             id="search-bar"
@@ -69,8 +69,7 @@ class TopMenu extends Component {
             compactMode
           />
         </div>
-        <div className="w-20 vtex-button bw1 ba fw5 ttu br2 fw4 v-mid relative pv3 ph5 f7 bg-transparent b--transparent c-muted-1 hover-b--transparent hover-c-action-primary pointer ">
-          <span onClick={e => this.setState({ searchActive: !searchActive })} >{this.translate('search-cancel')}</span>
+        <div className="w-20"><Button size="small" variation="tertiary" onClick={e => this.setState({ searchActive: !searchActive })} >CANCEL</Button>
         </div>
       </div>
     )
@@ -117,7 +116,7 @@ class TopMenu extends Component {
         'vtex-top-menu-fixed fixed bw1 bb b--light-gray top-0 z-999': fixed,
       },
       {
-        'vtex-top-menu-static' : !fixed,
+        'vtex-top-menu-static': !fixed,
       }
     )
     return (

--- a/react/components/TopMenu.js
+++ b/react/components/TopMenu.js
@@ -95,7 +95,7 @@ class TopMenu extends Component {
             labelClasses="gray"
             iconSize={mobileMode ? LOGIN_ICON_SIZE_MOBILE : LOGIN_ICON_SIZE_DESKTOP}
             iconLabel={!mobileMode ? this.translate('topMenu.login.icon.label') : ''}
-          />}
+          />
         </div>
         {!leanMode && <ExtensionPoint
           id="minicart"

--- a/react/components/TopMenu.js
+++ b/react/components/TopMenu.js
@@ -61,7 +61,7 @@ class TopMenu extends Component {
 
   renderMobileSearchBar(searchActive) {
     return (
-      <div className="flex justify-start pa2 pb3 relative w-100">
+      <div className="flex justify-start pa2 pt3 relative w-100">
         <div className="w-80">
           <ExtensionPoint
             id="search-bar"
@@ -69,7 +69,7 @@ class TopMenu extends Component {
             compactMode
           />
         </div>
-        <div className="w-20 vtex-button bw1 ba fw5 ttu br2 fw4 v-mid relative pv3 ph5 f6 bg-transparent b--transparent c-muted-1 hover-b--transparent hover-c-action-primary pointer ">
+        <div className="w-20 vtex-button bw1 ba fw5 ttu br2 fw4 v-mid relative pv3 ph5 f7 bg-transparent b--transparent c-muted-1 hover-b--transparent hover-c-action-primary pointer ">
           <span onClick={e => this.setState({ searchActive: !searchActive })} >{this.translate('search-cancel')}</span>
         </div>
       </div>
@@ -78,7 +78,7 @@ class TopMenu extends Component {
 
 
   renderIcons(mobileMode) {
-    const { leanMode, fixed, showLogin } = this.props
+    const { leanMode, fixed, showLogin, showSearchBar } = this.props
     const { searchActive } = this.state
 
     return (
@@ -86,7 +86,7 @@ class TopMenu extends Component {
         `vtex-top-menu__icons flex justify-end items-center w-25-m w-30-l ${mobileMode ? 'order-1 ml-auto' : 'order-2'}`
       }>
         <div className="mr7-m">
-          {(mobileMode && fixed) && showLogin && <Button icon variation="tertiary" onClick={e => this.setState({ searchActive: !searchActive })}>
+          {(mobileMode && fixed && showSearchBar) && showLogin && <Button icon variation="tertiary" onClick={e => this.setState({ searchActive: !searchActive })}>
             <IconSearch size={mobileMode ? SEARCH_ICON_SIZE_MOBILE : SEARCH_ICON_SIZE_DESKTOP} color="gray" />
           </Button>}
           <ExtensionPoint

--- a/react/components/TopMenu.js
+++ b/react/components/TopMenu.js
@@ -19,6 +19,8 @@ const SEARCH_ICON_SIZE_MOBILE = 20
 const SEARCH_ICON_SIZE_DESKTOP = 30
 
 class TopMenu extends Component {
+
+  state = { searchActive: false }
   translate = id => this.props.intl.formatMessage({ id: `header.${id}` })
 
   renderLogo(mobileMode, logoUrl, logoTitle) {
@@ -45,7 +47,7 @@ class TopMenu extends Component {
   }
 
   renderSearchBar(mobileMode) {
-    const { showSearchBar, fixed } = this.props
+    const { fixed, showSearchBar } = this.props
     const searchBar = <ExtensionPoint
       id="search-bar"
       placeholder={this.translate('search-placeholder')}
@@ -67,7 +69,7 @@ class TopMenu extends Component {
         `vtex-top-menu__icons flex justify-end items-center w-25-m w-30-l ${mobileMode ? 'order-1 ml-auto' : 'order-2'}`
       }>
         <div className="mr7-m">
-          {(mobileMode && fixed) && showLogin && <Button icon variation="tertiary">
+          {(mobileMode && fixed) && showLogin && <Button icon variation="tertiary" onClick={e => this.setState({ searchActive: !searchActive })}>
             <IconSearch size={mobileMode ? SEARCH_ICON_SIZE_MOBILE : SEARCH_ICON_SIZE_DESKTOP} color="gray" />
           </Button>}
           <ExtensionPoint
@@ -91,7 +93,7 @@ class TopMenu extends Component {
 
   render() {
     const { logoUrl, logoTitle, leanMode, fixed } = this.props
-
+    const { searchActive } = this.state
     const containerClasses = classNames(
       'vtex-top-menu flex justify-center w-100 bg-white',
       {
@@ -112,10 +114,22 @@ class TopMenu extends Component {
               <div className={containerClasses}>
                 <div className={contentClasses}>
                   <div className="flex-wrap flex-nowrap-ns flex w-100 justify-between-m items-center">
-                    {mobileMode && this.renderMobileMenu()}
-                    {this.renderLogo(mobileMode, logoUrl, logoTitle)}
+                    {!searchActive && mobileMode && this.renderMobileMenu()}
+                    {!searchActive && this.renderLogo(mobileMode, logoUrl, logoTitle)}
                     {!leanMode && this.renderSearchBar(mobileMode)}
-                    {this.renderIcons(mobileMode)}
+                    {!searchActive && this.renderIcons(mobileMode)}
+                    {(searchActive && <div className="flex justify-start pa2">
+                      <div className="w-90">
+                        <ExtensionPoint
+                          id="search-bar"
+                          placeholder={this.translate('search-placeholder')}
+                          emptyPlaceholder={this.translate('search-emptyPlaceholder')}
+                        />
+                      </div>
+                      <div className="w-10"><Button size="small" variation="tertiary"  onClick={e => this.setState({ searchActive: !searchActive })} >CANCEL</Button>
+                      </div>
+                    </div>
+                    )}
                   </div>
                 </div>
               </div>

--- a/react/components/TopMenu.js
+++ b/react/components/TopMenu.js
@@ -41,20 +41,22 @@ class TopMenu extends Component {
   }
 
   renderSearchBar(mobileMode) {
-    const { showSearchBar } = this.props
+    const { showSearchBar, fixed } = this.props
+    const searchBar = <ExtensionPoint
+      id="search-bar"
+      placeholder={this.translate('search-placeholder')}
+      emptyPlaceholder={this.translate('search-emptyPlaceholder')}
+    />
     return showSearchBar && (
       <div className={`vtex-top-menu__search-bar flex pa2-m w-100 w-50-m w-40-l ${mobileMode ? 'order-2' : 'order-1'}`}>
-        <ExtensionPoint
-          id="search-bar"
-          placeholder={this.translate('search-placeholder')}
-          emptyPlaceholder={this.translate('search-emptyPlaceholder')}
-        />
+        {mobileMode ? (mobileMode && !fixed) && searchBar : searchBar}
       </div>
     )
   }
 
   renderIcons(mobileMode) {
-    const { leanMode, showLogin } = this.props
+    const { leanMode, showLogin, fixed } = this.props
+
     return (
       <div className={
         `vtex-top-menu__icons flex justify-end items-center w-25-m w-30-l ${mobileMode ? 'order-1 ml-auto' : 'order-2'}`

--- a/react/components/TopMenu.js
+++ b/react/components/TopMenu.js
@@ -65,13 +65,13 @@ class TopMenu extends Component {
         <div className="w-80">
           <ExtensionPoint
             id="search-bar"
-            placeholder={this.translate('search-placeholder')}
+            placeholder=" "
             emptyPlaceholder={this.translate('search-emptyPlaceholder')}
             mobileMode
           />
         </div>
         <div className="w-20">
-          <Button className="right-0" size="small" variation="tertiary" onClick={e => this.setState({ searchActive: !searchActive })} >{this.translate('search-cancel')}</Button>
+          <Button className="right-0 black-90" size="small" variation="tertiary" onClick={e => this.setState({ searchActive: !searchActive })} >{this.translate('search-cancel')}</Button>
         </div>
       </div>
     )

--- a/react/components/TopMenu.js
+++ b/react/components/TopMenu.js
@@ -65,13 +65,12 @@ class TopMenu extends Component {
         <div className="w-80">
           <ExtensionPoint
             id="search-bar"
-            placeholder=" "
             emptyPlaceholder={this.translate('search-emptyPlaceholder')}
-            mobileMode
+            compactMode
           />
         </div>
-        <div className="w-20">
-          <Button className="right-0 black-90" size="small" variation="tertiary" onClick={e => this.setState({ searchActive: !searchActive })} >{this.translate('search-cancel')}</Button>
+        <div className="w-20 vtex-button bw1 ba fw5 ttu br2 fw4 v-mid relative pv3 ph5 f6 bg-transparent b--transparent c-muted-1 hover-b--transparent hover-c-action-primary pointer ">
+          <span onClick={e => this.setState({ searchActive: !searchActive })} >{this.translate('search-cancel')}</span>
         </div>
       </div>
     )

--- a/react/components/TopMenu.js
+++ b/react/components/TopMenu.js
@@ -61,7 +61,7 @@ class TopMenu extends Component {
 
   renderMobileSearchBar(searchActive) {
     return (
-      <div className="flex justify-start pa1 pr6 pt3 relative w-100">
+      <div className="flex justify-start pa2 pr4 pt3 relative w-100">
         <div className="w-80">
           <ExtensionPoint
             id="search-bar"
@@ -69,7 +69,7 @@ class TopMenu extends Component {
             compactMode
           />
         </div>
-        <div className="w-20"><Button size="small" variation="tertiary" onClick={e => this.setState({ searchActive: !searchActive })} >CANCEL</Button>
+        <div className="w-20 pl0"><Button size="small" variation="tertiary" onClick={e => this.setState({ searchActive: !searchActive })} >CANCEL</Button>
         </div>
       </div>
     )

--- a/react/components/TopMenu.js
+++ b/react/components/TopMenu.js
@@ -60,6 +60,23 @@ class TopMenu extends Component {
     )
   }
 
+  renderMobileSearchBar(searchActive) {
+    return (
+      <div className="flex justify-start pa2">
+        <div className="w-90">
+          <ExtensionPoint
+            id="search-bar"
+            placeholder={this.translate('search-placeholder')}
+            emptyPlaceholder={this.translate('search-emptyPlaceholder')}
+          />
+        </div>
+        <div className="w-10"><Button size="small" variation="tertiary" onClick={e => this.setState({ searchActive: !searchActive })} >CANCEL</Button>
+        </div>
+      </div>
+    )
+  }
+
+
   renderIcons(mobileMode) {
     const { leanMode, fixed, showLogin } = this.props
     const { searchActive } = this.state
@@ -116,20 +133,9 @@ class TopMenu extends Component {
                   <div className="flex-wrap flex-nowrap-ns flex w-100 justify-between-m items-center">
                     {!searchActive && mobileMode && this.renderMobileMenu()}
                     {!searchActive && this.renderLogo(mobileMode, logoUrl, logoTitle)}
-                    {!leanMode && this.renderSearchBar(mobileMode)}
+                    {!searchActive && !leanMode && this.renderSearchBar(mobileMode)}
                     {!searchActive && this.renderIcons(mobileMode)}
-                    {(searchActive && <div className="flex justify-start pa2">
-                      <div className="w-90">
-                        <ExtensionPoint
-                          id="search-bar"
-                          placeholder={this.translate('search-placeholder')}
-                          emptyPlaceholder={this.translate('search-emptyPlaceholder')}
-                        />
-                      </div>
-                      <div className="w-10"><Button size="small" variation="tertiary"  onClick={e => this.setState({ searchActive: !searchActive })} >CANCEL</Button>
-                      </div>
-                    </div>
-                    )}
+                    {(searchActive && this.renderMobileSearchBar(searchActive))}
                   </div>
                 </div>
               </div>

--- a/react/components/TopMenu.js
+++ b/react/components/TopMenu.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import { intlShape, injectIntl } from 'react-intl'
 import { ExtensionPoint, Link } from 'render'
 import { Button, IconSearch } from 'vtex.styleguide'
-
 import classNames from 'classnames'
 import ReactResizeDetector from 'react-resize-detector'
 
@@ -62,15 +61,17 @@ class TopMenu extends Component {
 
   renderMobileSearchBar(searchActive) {
     return (
-      <div className="flex justify-start pa2">
-        <div className="w-90">
+      <div className="flex justify-start pa2 relative w-100">
+        <div className="w-80">
           <ExtensionPoint
             id="search-bar"
             placeholder={this.translate('search-placeholder')}
             emptyPlaceholder={this.translate('search-emptyPlaceholder')}
+            mobileMode
           />
         </div>
-        <div className="w-10"><Button size="small" variation="tertiary" onClick={e => this.setState({ searchActive: !searchActive })} >CANCEL</Button>
+        <div className="w-20">
+          <Button className="right-0" size="small" variation="tertiary" onClick={e => this.setState({ searchActive: !searchActive })} >{this.translate('search-cancel')}</Button>
         </div>
       </div>
     )
@@ -126,7 +127,6 @@ class TopMenu extends Component {
           width => {
             const mobileMode = width < 640 || (global.__RUNTIME__.hints.mobile && (!width || width < 640))
             const contentClasses = `w-100 w-90-l center flex justify-center  ${mobileMode & !fixed ? 'pb4' : ''}  pv2-m pv6-l ph3-s ph7-m ph6-xl`
-
             return (
               <div className={containerClasses}>
                 <div className={contentClasses}>

--- a/react/components/TopMenu.js
+++ b/react/components/TopMenu.js
@@ -10,11 +10,11 @@ const LOGO_WIDTH_MOBILE = 90
 const LOGO_WIDTH_DESKTOP = 150
 const LOGO_HEIGHT_MOBILE = 30
 const LOGO_HEIGHT_DESKTOP = 50
-const MINICART_ICON_SIZE_MOBILE = 23
+const MINICART_ICON_SIZE_MOBILE = 22
 const MINICART_ICON_SIZE_DESKTOP = 30
-const LOGIN_ICON_SIZE_MOBILE = 23
+const LOGIN_ICON_SIZE_MOBILE = 22
 const LOGIN_ICON_SIZE_DESKTOP = 30
-const SEARCH_ICON_SIZE_MOBILE = 20
+const SEARCH_ICON_SIZE_MOBILE = 22
 const SEARCH_ICON_SIZE_DESKTOP = 30
 
 class TopMenu extends Component {
@@ -61,7 +61,7 @@ class TopMenu extends Component {
 
   renderMobileSearchBar(searchActive) {
     return (
-      <div className="flex justify-start pa2 relative w-100">
+      <div className="flex justify-start pa2 pb3 relative w-100">
         <div className="w-80">
           <ExtensionPoint
             id="search-bar"

--- a/react/index.js
+++ b/react/index.js
@@ -2,10 +2,8 @@ import React, { Component, Fragment } from 'react'
 import PropTypes from 'prop-types'
 import { injectIntl, intlShape } from 'react-intl'
 import hoistNonReactStatics from 'hoist-non-react-statics'
-
 import Modal from './components/Modal'
 import TopMenu from './components/TopMenu'
-
 import { Alert } from 'vtex.styleguide'
 import { ExtensionPoint, withRuntimeContext } from 'render'
 

--- a/react/locales/en-US.json
+++ b/react/locales/en-US.json
@@ -8,6 +8,5 @@
   "header.search-emptyPlaceholder": "No matches found",
   "header.topMenu.minicart.icon.label": "My Cart",
   "header.topMenu.login.icon.label": "Sign in",
-  "header.topMenu.search-cancel": "CANCEL"
-
+  "header.search-cancel": "CANCEL"
 }

--- a/react/locales/en-US.json
+++ b/react/locales/en-US.json
@@ -7,5 +7,7 @@
   "header.search-placeholder": "Search for products, brands...",
   "header.search-emptyPlaceholder": "No matches found",
   "header.topMenu.minicart.icon.label": "My Cart",
-  "header.topMenu.login.icon.label": "Sign in"
+  "header.topMenu.login.icon.label": "Sign in",
+  "header.topMenu.search-cancel": "CANCEL"
+
 }

--- a/react/locales/es-AR.json
+++ b/react/locales/es-AR.json
@@ -8,6 +8,5 @@
   "header.search-emptyPlaceholder": "Ningún resultado encontrado",
   "header.topMenu.minicart.icon.label": "Mi Cesta",
   "header.topMenu.login.icon.label": "Entrar",
-  "header.topMenu.search-cancel": "CANCEL"
-
+  "header.topMenu.search-cancel": "CANCELAR"
 }

--- a/react/locales/es-AR.json
+++ b/react/locales/es-AR.json
@@ -7,5 +7,7 @@
   "header.search-placeholder": "Búsqueda por productos, marcas...",
   "header.search-emptyPlaceholder": "Ningún resultado encontrado",
   "header.topMenu.minicart.icon.label": "Mi Cesta",
-  "header.topMenu.login.icon.label": "Entrar"
+  "header.topMenu.login.icon.label": "Entrar",
+  "header.topMenu.search-cancel": "CANCEL"
+
 }

--- a/react/locales/es-AR.json
+++ b/react/locales/es-AR.json
@@ -8,5 +8,5 @@
   "header.search-emptyPlaceholder": "Ningún resultado encontrado",
   "header.topMenu.minicart.icon.label": "Mi Cesta",
   "header.topMenu.login.icon.label": "Entrar",
-  "header.topMenu.search-cancel": "CANCELAR"
+  "header.search-cancel": "CANCELAR"
 }

--- a/react/locales/pt-BR.json
+++ b/react/locales/pt-BR.json
@@ -7,5 +7,6 @@
   "header.search-placeholder": "Busque por produtos, marcas...",
   "header.search-emptyPlaceholder": "Nenhum resultado encontrado",
   "header.topMenu.minicart.icon.label": "Meu Carrinho",
-  "header.topMenu.login.icon.label": "Entrar"
+  "header.topMenu.login.icon.label": "Entrar", 
+  "header.search-cancel": "CANCEL"
 }

--- a/react/locales/pt-BR.json
+++ b/react/locales/pt-BR.json
@@ -7,6 +7,6 @@
   "header.search-placeholder": "Busque por produtos, marcas...",
   "header.search-emptyPlaceholder": "Nenhum resultado encontrado",
   "header.topMenu.minicart.icon.label": "Meu Carrinho",
-  "header.topMenu.login.icon.label": "Entrar", 
-  "header.search-cancel": "CANCEL"
+  "header.topMenu.login.icon.label": "Entrar",
+  "header.search-cancel": "CANCELAR"
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Change the header to the proposed design below.
<img width="1538" alt="header" src="https://user-images.githubusercontent.com/17649410/48065241-f2428080-e1a8-11e8-94ce-ad4893774c15.png">

#### How should this be manually tested?
https://header--storecomponents.myvtex.com/

#### Screenshots or example usage
Before: 
![before-header-compact](https://user-images.githubusercontent.com/17649410/48153937-2a7bb900-e2a6-11e8-8689-d404fd26f594.png)

After:

![after-header-compact](https://user-images.githubusercontent.com/17649410/48153940-2d76a980-e2a6-11e8-9090-7c9313842348.png)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
