### PR TITLE
Fix/scroll threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Fixed bug where topbar was permanently fixed when scrolling
+- Fixed bug where content was jumping around when the header was set to fixed
+
 ## [1.3.1] - 2018-11-06
 
 ### Fixed

--- a/react/index.js
+++ b/react/index.js
@@ -90,7 +90,6 @@ class Header extends Component {
       logoUrl,
       logoTitle,
       leanMode,
-      fixed: showMenuPopup,
       showSearchBar,
       showLogin,
     }
@@ -109,7 +108,7 @@ class Header extends Component {
           {!leanMode && <ExtensionPoint id="category-menu" />}
           {showMenuPopup && (
             <Modal>
-              <TopMenu {...topMenuOptions} />
+              <TopMenu fixed {...topMenuOptions} />
             </Modal>
           )}
           <div


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fixes bug where header was getting permanently fixed after scrolling. 
Also fixes a bug, caused by the same issue, where content would jump around when the topbar was set to fixed.

(workspace: https://lbebber--delivery.myvtex.com/pizza-pepperoni/p)

Before:
![header-before](https://user-images.githubusercontent.com/5691711/48069297-430fa480-e1bc-11e8-8ce5-4970a5f10718.gif)

After:
![header-after](https://user-images.githubusercontent.com/5691711/48069339-591d6500-e1bc-11e8-83c4-d0bf2e5dc0a9.gif)



#### Screenshots or example usage

#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
