### PR TITLE
Fix/top menu classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added the classes `vtex-top-menu-fixed` and `vtex-top-menu-static` to each respective stage of the top menu.
+
 ## [1.3.3] - 2018-11-06
 ### Fixed
 - Fixes `showSearchBar should be a function` error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.4.0] - 2018-11-07
+
 ### Added
 
 - Added the classes `vtex-top-menu-fixed` and `vtex-top-menu-static` to each respective stage of the top menu.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "dreamstore-header",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "title": "VTEX Header",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Header component",

--- a/react/components/TopMenu.js
+++ b/react/components/TopMenu.js
@@ -85,7 +85,10 @@ class TopMenu extends Component {
     const containerClasses = classNames(
       'vtex-top-menu flex justify-center w-100 bg-white',
       {
-        'fixed bw1 bb b--light-gray top-0 z-999': fixed,
+        'vtex-top-menu-fixed fixed bw1 bb b--light-gray top-0 z-999': fixed,
+      },
+      {
+        'vtex-top-menu-static' : !fixed,
       }
     )
     const contentClasses = 'w-100 w-90-l center flex justify-center pb4 pv2-m pv6-l ph3-s ph7-m ph6-xl'


### PR DESCRIPTION
#### What is the purpose of this pull request?
Added the classes `vtex-top-menu-fixed` and `vtex-top-menu-static` to each respective stage of the top menu, so that external apps can target the menu more specifically.

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
