### PR TITLE
Fix/topbar fixed visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.5.1] - 2018-11-07
+
 ### Fixed
 
 - The "fixed" topbar is always being rendered, and its visibility is toggled now instead. This is so its height can be always calculable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- The "fixed" topbar is always being rendered, and its visibility is toggled now instead. This is so its height can be always calculable.
+
 ## [1.5.0] - 2018-11-07
+
 ### Added
 - Hide the `SearchBar` when scroll the page in mobile devices. 
 - In the above scenario, a icon is displayed and when clicked the `Searchbar` is rendered.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "dreamstore-header",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "title": "VTEX Header",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Header component",

--- a/react/index.js
+++ b/react/index.js
@@ -104,11 +104,9 @@ class Header extends Component {
           </div>
           <TopMenu {...topMenuOptions} />
           {!leanMode && <ExtensionPoint id="category-menu" />}
-          <Modal>
-            <div style={{ visibility: showMenuPopup ? 'inherit' : 'hidden' }}>
-              <TopMenu fixed {...topMenuOptions} />
-            </div>
-          </Modal>
+          <div style={{ visibility: showMenuPopup ? 'inherit' : 'hidden' }}>
+            <TopMenu fixed {...topMenuOptions} />
+          </div>
           <div
             className="flex flex-column items-center fixed w-100"
             style={{ top: offsetTop + 120 }}

--- a/react/index.js
+++ b/react/index.js
@@ -104,11 +104,11 @@ class Header extends Component {
           </div>
           <TopMenu {...topMenuOptions} />
           {!leanMode && <ExtensionPoint id="category-menu" />}
-          {showMenuPopup && (
-            <Modal>
+          <Modal>
+            <div style={{ visibility: showMenuPopup ? 'inherit' : 'hidden' }}>
               <TopMenu fixed {...topMenuOptions} />
-            </Modal>
-          )}
+            </div>
+          </Modal>
           <div
             className="flex flex-column items-center fixed w-100"
             style={{ top: offsetTop + 120 }}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Makes "fixed" topbar always renderable, and toggles its visibility instead. 
This is so its height can be always calculable—specifically for the product customizer app, and other possible apps eventually, to know how much to scroll.


#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
