### PR TITLE
Fix bottom padding problem in SearchBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- No padding being applied in the `SearchBar` bottom in mobile mode.
 
 ## [2.1.2] - 2018-12-04
 ### Fixed

--- a/react/components/TopMenu.js
+++ b/react/components/TopMenu.js
@@ -124,7 +124,7 @@ class TopMenu extends Component {
         {
           width => {
             const mobileMode = width < 640 || (global.__RUNTIME__.hints.mobile && (!width || width < 640))
-            const contentClasses = `w-100 center flex justify-center pv2-m pv6-l ph3 ph5-m ph8-l ph9-xl`
+            const contentClasses = `w-100 center flex justify-center pv2-m pv6-l ph3 pb3-s ph5-m ph8-l ph9-xl`
             return (
               <div className={containerClasses}>
                 <div className={contentClasses}>


### PR DESCRIPTION
#### What is the purpose of this pull request? What problem is this solving?
As the title says.

#### How should this be manually tested?
Open this [Workspace](https://dreamstorheaderpadding--storecomponents.myvtex.com/) in mobile mode and check the `SearchBar` spacing in the bottom

#### Screenshots or example usage
![captura de tela de 2018-12-04 14-17-40](https://user-images.githubusercontent.com/8517023/49460112-5d469d80-f7cf-11e8-9e02-5a03f01c951d.png)


#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
